### PR TITLE
Add tonaparser

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -36,6 +36,7 @@ resolver: lts-11.13
 # non-dependency (i.e. a user package), and its test suites and benchmarks
 # will not be run. This is useful for tweaking upstream packages.
 packages:
+    - 'tonaparser'
     - 'tonatona'
     - 'tonatona-db-postgresql'
     - 'tonatona-db-sqlite'

--- a/tonaparser/LICENSE
+++ b/tonaparser/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 ARoW Co., Ltd. https://arow.info
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tonaparser/Makefile
+++ b/tonaparser/Makefile
@@ -1,0 +1,57 @@
+.PHONY: build clean dump-th ghci haddock haddock-server hlint lint repl test watch watch-haddock watch-tests watch-test
+all: build
+
+build:
+	stack build tonaparser
+
+clean:
+	stack clean
+
+# dump the template haskell
+# (you must have a compile error in the code you want to dump)
+dump-th:
+	-stack build --ghc-options="-ddump-splices"
+	@echo
+	@echo "Splice files:"
+	@echo
+	@find "$$(stack path --dist-dir)" -name "*.dump-splices"
+
+ghci:
+	stack ghci
+
+heroku-release:
+	heroku container:push web
+
+haddock:
+	stack build --haddock
+
+# This runs a small python websever on port 8001 serving up haddocks for
+# packages you have installed.
+#
+# In order to run this, you need to have run `make build-haddock`.
+haddock-server:
+	cd "$$(stack path --local-doc-root)" && python -m http.server 8001
+
+hlint: lint
+
+lint:
+	hlint src/
+
+# Start a repl.
+repl: ghci
+
+test:
+	stack test
+
+# Watch for changes.
+watch:
+	stack build --file-watch --fast tonaparser
+
+# Watch for changes while trying to build haddocks
+watch-haddock:
+	stack build --haddock --file-watch --fast tonaparser
+
+# Watch for changes.
+watch-test: watch-tests
+watch-tests:
+	stack test --file-watch --fast tonaparser

--- a/tonaparser/README.md
+++ b/tonaparser/README.md
@@ -1,0 +1,3 @@
+# meta-config-parser
+
+A parser which can parse env vars and command line args at once.

--- a/tonaparser/Setup.hs
+++ b/tonaparser/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/tonaparser/example/Main.hs
+++ b/tonaparser/example/Main.hs
@@ -5,13 +5,13 @@ import Data.Semigroup ((<>))
 import TonaParser
   ( FromEnv(fromEnv)
   , Parser
-  , ParserAlts(..)
+  , ParserRenames(..)
   , ParserMods(..)
   , (.||)
   , argLong
   , argShort
   , decodeEnvWith
-  , defParserAlts
+  , defParserRenames
   , defParserMods
   , env
   , envDef
@@ -51,11 +51,11 @@ instance FromEnv Foo where
 
 main :: IO ()
 main = do
-  let alts =
-        defParserAlts
-          { cmdLineLongAlts = [("foo", "new-foo")]
-          , cmdLineShortAlts = [('b', 'c')]
-          , envVarAlts = [("BAR_BAZ", "NEW_BAR_BAZ")]
+  let renames =
+        defParserRenames
+          { cmdLineLongRenames = [("foo", "new-foo")]
+          , cmdLineShortRenames = [('b', 'c')]
+          , envVarRenames = [("BAR_BAZ", "NEW_BAR_BAZ")]
           }
-  (foo :: Maybe Foo) <- decodeEnvWith alts defParserMods
+  (foo :: Maybe Foo) <- decodeEnvWith renames defParserMods
   print foo

--- a/tonaparser/example/Main.hs
+++ b/tonaparser/example/Main.hs
@@ -55,7 +55,7 @@ main = do
         defParserAlts
           { cmdLineLongAlts = [("foo", "new-foo")]
           , cmdLineShortAlts = [('b', 'c')]
-          , envVarAlts = [("BAZ", "NEW_BAZ")]
+          , envVarAlts = [("BAR_BAZ", "NEW_BAR_BAZ")]
           }
   (foo :: Maybe Foo) <- decodeEnvWith alts defParserMods
   print foo

--- a/tonaparser/example/Main.hs
+++ b/tonaparser/example/Main.hs
@@ -1,9 +1,14 @@
 module Main where
 
-import TonaParser (FromEnv(fromEnv), (.||), argLong, argShort, decodeEnv, envDef, envVar)
+import TonaParser (FromEnv(fromEnv), (.||), argLong, argShort, decodeEnv, env, envDef, envVar)
 
 data Bar = Bar
   { baz :: String
+  } deriving Show
+
+data Foo = Foo
+  { foo :: Int
+  , bar :: Bar
   } deriving Show
 
 -- If environment variable "BAZ" exist, use the value
@@ -14,7 +19,12 @@ instance FromEnv Bar where
   fromEnv = Bar
     <$> envDef (envVar "BAZ" .|| argLong "baz" .|| argShort 'b') "baz"
 
+instance FromEnv Foo where
+  fromEnv = Foo
+    <$> env (envVar "FOO" .|| argLong "foo")
+    <*> fromEnv
+
 main :: IO ()
 main = do
-  (bar :: Maybe Bar) <- decodeEnv
-  print bar
+  (foo :: Maybe Foo) <- decodeEnv
+  print foo

--- a/tonaparser/example/Main.hs
+++ b/tonaparser/example/Main.hs
@@ -1,0 +1,20 @@
+module Main where
+
+import TonaParser (FromEnv(fromEnv), (.||), argLong, argShort, decodeEnv, envDef, envVar)
+
+data Bar = Bar
+  { baz :: String
+  } deriving Show
+
+-- If environment variable "BAZ" exist, use the value
+-- else if command line argument "--baz" exist, use the value
+-- else if command line argument "-b" exist, use the value
+-- else use default value "baz"
+instance FromEnv Bar where
+  fromEnv = Bar
+    <$> envDef (envVar "BAZ" .|| argLong "baz" .|| argShort 'b') "baz"
+
+main :: IO ()
+main = do
+  (bar :: Maybe Bar) <- decodeEnv
+  print bar

--- a/tonaparser/example/Main.hs
+++ b/tonaparser/example/Main.hs
@@ -1,6 +1,6 @@
 module Main where
 
-import TonaParser (FromEnv(fromEnv), (.||), argLong, argShort, decodeEnv, env, envDef, envVar)
+import TonaParser (FromEnv(fromEnv), (.||), argLong, argShort, decodeEnvWithMod, env, envDef, envVar)
 
 data Bar = Bar
   { baz :: String
@@ -26,5 +26,6 @@ instance FromEnv Foo where
 
 main :: IO ()
 main = do
-  (foo :: Maybe Foo) <- decodeEnv
+  (foo :: Maybe Foo) <-
+    decodeEnvWithMod [("BAZ", "NEW_BAZ")] [("foo", "new-foo")] [('b', 'c')]
   print foo

--- a/tonaparser/src/TonaParser.hs
+++ b/tonaparser/src/TonaParser.hs
@@ -6,8 +6,12 @@ import Control.Monad.Except (ExceptT, MonadError)
 import Control.Monad.IO.Class (MonadIO)
 import Control.Monad.Reader (ReaderT, runReaderT, reader)
 import Control.Monad.Trans (lift)
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.Maybe (listToMaybe, mapMaybe)
 import Data.Semigroup ((<>))
-import System.Envy (FromEnv, decodeEnv)
+import System.Environment (getArgs, getEnvironment)
+import System.Envy (Var(fromVar))
 
 {-| Example
 
@@ -45,33 +49,117 @@ import System.Envy (FromEnv, decodeEnv)
       <*> barWithPrefix
  -}
 
+-- data Foo = Foo
+--   { foo :: Int
+--   , bar :: Bar
+--   }
+
+data Bar = Bar
+  { baz :: String
+  }
+
+-- If environment variable "BAZ" exist, use the value
+-- else if command line argument "--baz" exist, use the value
+-- else if command line argument "-b" exist, use the value
+-- else use default value "baz"
+instance FromEnv Bar where
+  fromEnv = Bar
+    <$> envDef (envVar "BAZ" .|| argLong "baz" .|| argShort 'b') "baz"
+
+-- If environment variable "BAR_BAZ" exist, use the value
+-- else if command line argument "--bar-baz" exist, use the value
+-- else use default value "baz"
+-- ( short hands argument "-b" was deactivated )
+-- barWithPrefix :: Parser a
+-- barWithPrefix =
+--   modifyConfig $
+--     modifyEnvVarKey ("BAR_" <>) .
+--     modifyArgLongKey ("bar-" <>) .
+--     modifyArgShortKey const Nothing
+
+-- FromEnv Foo where
+--   fromEnv = Foo
+--     <$> env (envVar "FOO" .|| argLong "foo")
+--     <*> barWithPrefix
 
 
 class FromEnv a where
   fromEnv :: Parser a
 
+decodeEnv :: FromEnv a => IO (Maybe a)
+decodeEnv = do
+  let parser = fromEnv
+  envVars <- getEnvVars
+  cmdLineArgs <- getCmdLineArgs
+  pure $ runParser parser envVars cmdLineArgs
+
+runParser :: Parser a -> Map String String -> [(String, String)] -> Maybe a
+runParser (Parser parserFunc) envVars cmdLineArgs =
+  let conf =
+        Config
+          { confCmdLineArgs = cmdLineArgs
+          , confEnvVars = envVars
+          }
+  in parserFunc conf
+
+getEnvVars :: IO (Map String String)
+getEnvVars = do
+  environment <- getEnvironment
+  pure $ Map.fromList environment
+
+-- TODO: Does not properly handle command line arguments.
+-- Probably should use parsing code from something like optparse-applicative.
+getCmdLineArgs :: IO [(String, String)]
+getCmdLineArgs = do
+  args <- getArgs
+  pure $ tupleList args
+  where
+    -- This throws away the last time if the input list is not even.
+    tupleList :: [a] -> [(a,a)]
+    tupleList (a:b:cs) = (a, b) : tupleList cs
+    tupleList _ = []
+
+env :: Var a => Source -> Parser a
+env (Source srcs) =
+  Parser $ \conf -> do
+    -- find matching source
+    val <- findValInSrc conf srcs
+    fromVar val
+
+findValInSrc :: Config -> [InnerSource] -> Maybe String
+findValInSrc conf srcs = listToMaybe $ mapMaybe (findValInSrcs conf) srcs
+
+findValInSrcs :: Config -> InnerSource -> Maybe String
+findValInSrcs (Config cmdLineArgs _) (ArgLong str) = lookup str cmdLineArgs
+findValInSrcs (Config cmdLineArgs _) (ArgShort ch) = lookup [ch] cmdLineArgs
+findValInSrcs (Config _ envVars) (EnvVar var) = Map.lookup var envVars
+
+envDef :: Var a => Source -> a -> Parser a
+envDef src df = Parser $ \conf ->
+  let Parser f = env src
+  in
+  case f conf of
+    Nothing -> Just df
+    Just a -> Just a
+
 newtype Parser a = Parser
-  { getConfig :: Config a
+  { getConfig :: Config -> Maybe a
   }
-  -- deriving ( Functor
-  --            , Monad
-  --            , Applicative
-  --            , MonadError String
-  --            , MonadIO
-  --            , Alternative
-  --            , MonadPlus
-  --            )
-
-
-runParser :: ExceptT String IO a
-runParser = undefined
+  deriving (Functor
+             -- , Monad
+             -- , Applicative
+             -- , MonadError String
+             -- , MonadIO
+             -- , Alternative
+             -- , MonadPlus
+             )
 
 
 {-| Opaque type.
  -}
-data Config a = Config
-  { defaultValue :: Maybe a
-  , sources :: [InnerSource]
+data Config = Config
+  { confCmdLineArgs :: [(String, String)]
+  , confEnvVars :: Map String String
   }
 
 
@@ -91,3 +179,9 @@ newtype Source = Source { unSource :: [InnerSource] }
 envVar :: String -> Source
 envVar name =
   Source [EnvVar name]
+
+argLong :: String -> Source
+argLong name = Source [ArgLong name]
+
+argShort :: Char -> Source
+argShort name = Source [ArgShort name]

--- a/tonaparser/src/TonaParser.hs
+++ b/tonaparser/src/TonaParser.hs
@@ -1,0 +1,89 @@
+module TonaParser
+  (..) where
+
+import Control.Monad.Reader (ReaderT, runReaderT, reader)
+import Control.Monad.Trans (lift)
+import Data.Semigroup ((<>))
+import System.Envy (FromEnv, decodeEnv)
+
+{-| Example
+
+  data Foo = Foo
+    { foo :: Int
+    , bar :: Bar
+    }
+
+  data Bar = Bar
+    { baz :: String
+    }
+
+  -- If environment variable "BAZ" exist, use the value
+  -- else if command line argument "--baz" exist, use the value
+  -- else if command line argument "-b" exist, use the value
+  -- else use default value "baz"
+  FromEnv Bar where
+    fromEnv = Bar
+      <$> envMaybe (envVar "BAZ" .|| argLong "baz" .|| argShort 'b') .!= "baz"
+
+  -- If environment variable "BAR_BAZ" exist, use the value
+  -- else if command line argument "--bar-baz" exist, use the value
+  -- else use default value "baz"
+  -- ( short hands argument "-b" was deactivated )
+  barWithPrefix :: Parser a
+  barWithPrefix =
+    modifyConfig $
+      modifyEnvVarKey ("BAR_" <>) .
+      modifyArgLongKey ("bar-" <>) .
+      modifyArgShortKey const Nothing
+
+  FromEnv Foo where
+    fromEnv = Foo
+      <$> env (envVar "FOO" .|| argLong "foo")
+      <*> barWithPrefix
+ -}
+
+
+
+class FromEnv a where
+  fromEnv :: Parser a
+
+newtype Parser a = Parser
+  { getConfig :: Config a
+  } deriving ( Functor
+             , Monad
+             , Applicative
+             , MonadError String
+             , MonadIO
+             , Alternative
+             , MonadPlus
+             )
+
+
+runParser :: ExceptT String IO a
+runParser = undefined
+
+
+{-| Opaque type.
+ -}
+data Config a = Config
+  { defaultValue :: Maybe a
+  , sources :: [InnerSource]
+  }
+
+
+data InnerSource
+  = EnvVar String
+  | ArgLong String
+  | ArgShort Char
+
+
+newtype Source = Source { unSource :: [InnerSource] }
+
+
+(.||) :: Source -> Source -> Source
+(.||) (Source a) (Source b) = Source (a ++ b)
+
+
+envVar :: String -> Source
+envVar name =
+  Source [EnvVar name]

--- a/tonaparser/src/TonaParser.hs
+++ b/tonaparser/src/TonaParser.hs
@@ -115,8 +115,8 @@ getCmdLineArgs = do
   pure $ tupleList args
   where
     -- This throws away the last time if the input list is not even.
-    tupleList :: [a] -> [(a,a)]
-    tupleList (a:b:cs) = (a, b) : tupleList cs
+    tupleList :: [String] -> [(String,String)]
+    tupleList (a:b:cs) = (dropWhile (== '-') a, b) : tupleList cs
     tupleList _ = []
 
 env :: Var a => Source -> Parser a

--- a/tonaparser/src/TonaParser.hs
+++ b/tonaparser/src/TonaParser.hs
@@ -1,6 +1,9 @@
-module TonaParser
-  (..) where
+module TonaParser where
 
+import Control.Applicative (Alternative)
+import Control.Monad (MonadPlus)
+import Control.Monad.Except (ExceptT, MonadError)
+import Control.Monad.IO.Class (MonadIO)
 import Control.Monad.Reader (ReaderT, runReaderT, reader)
 import Control.Monad.Trans (lift)
 import Data.Semigroup ((<>))
@@ -49,14 +52,15 @@ class FromEnv a where
 
 newtype Parser a = Parser
   { getConfig :: Config a
-  } deriving ( Functor
-             , Monad
-             , Applicative
-             , MonadError String
-             , MonadIO
-             , Alternative
-             , MonadPlus
-             )
+  }
+  -- deriving ( Functor
+  --            , Monad
+  --            , Applicative
+  --            , MonadError String
+  --            , MonadIO
+  --            , Alternative
+  --            , MonadPlus
+  --            )
 
 
 runParser :: ExceptT String IO a

--- a/tonaparser/test/DocTest.hs
+++ b/tonaparser/test/DocTest.hs
@@ -1,0 +1,54 @@
+
+module Main (main) where
+
+import Data.Semigroup ((<>))
+import System.FilePath.Glob (glob)
+import Test.DocTest (doctest)
+
+main :: IO ()
+main = glob "src/**/*.hs" >>= doDocTest
+
+doDocTest :: [String] -> IO ()
+doDocTest options =
+  doctest $
+    options <>
+    ghcExtensions <>
+    -- This was added because doctest was segfaulting:
+    -- https://github.com/sol/doctest/issues/162
+    ["-v"]
+
+ghcExtensions :: [String]
+ghcExtensions =
+    [ "-XConstraintKinds"
+    , "-XDataKinds"
+    , "-XDeriveDataTypeable"
+    , "-XDeriveFunctor"
+    , "-XDeriveGeneric"
+    , "-XDuplicateRecordFields"
+    , "-XEmptyDataDecls"
+    , "-XFlexibleContexts"
+    , "-XFlexibleInstances"
+    , "-XGADTs"
+    , "-XGeneralizedNewtypeDeriving"
+    , "-XInstanceSigs"
+    , "-XLambdaCase"
+    , "-XMultiParamTypeClasses"
+    , "-XNamedFieldPuns"
+    , "-XNoImplicitPrelude"
+    , "-XNoMonomorphismRestriction"
+    , "-XOverloadedLabels"
+    , "-XOverloadedLists"
+    , "-XOverloadedStrings"
+    , "-XPackageImports"
+    , "-XPatternSynonyms"
+    , "-XPolyKinds"
+    , "-XRankNTypes"
+    , "-XRecordWildCards"
+    , "-XScopedTypeVariables"
+    , "-XStandaloneDeriving"
+    , "-XTupleSections"
+    , "-XTypeApplications"
+    , "-XTypeFamilies"
+    , "-XTypeOperators"
+    , "-XViewPatterns"
+    ]

--- a/tonaparser/test/Spec.hs
+++ b/tonaparser/test/Spec.hs
@@ -1,0 +1,6 @@
+{-# LANGUAGE QuasiQuotes #-}
+
+module Main where
+
+main :: IO ()
+main = pure ()

--- a/tonaparser/tonaparser.cabal
+++ b/tonaparser/tonaparser.cabal
@@ -18,6 +18,7 @@ library
   hs-source-dirs:      src
   exposed-modules:     TonaParser
   build-depends:       base >= 4.7 && < 5
+                     , containers
                      , envy
                      , monad-logger
                      , mtl

--- a/tonaparser/tonaparser.cabal
+++ b/tonaparser/tonaparser.cabal
@@ -14,6 +14,11 @@ build-type:          Simple
 extra-source-files:  README.md
 cabal-version:       >=1.10
 
+flag buildexample
+  description: Build a small example program
+  default: False
+
+
 library
   hs-source-dirs:      src
   exposed-modules:     TonaParser
@@ -37,6 +42,27 @@ library
                      , RecordWildCards
                      , ScopedTypeVariables
                      , ViewPatterns
+
+executable tonaparser-example
+  hs-source-dirs:      example
+  main-is:             Main.hs
+  build-depends:       base >= 4.7 && < 5
+                     , tonaparser
+  ghc-options:         -threaded -rtsopts -with-rtsopts=-N -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates
+  default-language:    Haskell2010
+  default-extensions:  DefaultSignatures
+                     , DeriveDataTypeable
+                     , DeriveFunctor
+                     , DeriveGeneric
+                     , OverloadedStrings
+                     , RankNTypes
+                     , RecordWildCards
+                     , ScopedTypeVariables
+                     , ViewPatterns
+  if flag(buildexample)
+    buildable:         True
+  else
+    buildable:         False
 
 test-suite tonaparser-test
   type:                exitcode-stdio-1.0

--- a/tonaparser/tonaparser.cabal
+++ b/tonaparser/tonaparser.cabal
@@ -1,9 +1,9 @@
-name:                tonaparser.cabal
+name:                tonaparser
 version:             0.1.0.0
 synopsis:            meta web application framework
 description:
   `Tonatona` is **meta** web application framework, which handles lots of annoying and boring tasks on real world web development such as environment variables, logging, etc...
-homepage:            http://github.com/arow-oss/tonaparser/#readme
+homepage:            http://github.com/arow-oss/tonatona/#readme
 license:             MIT
 license-file:        LICENSE
 author:              ARoW Co., Ltd.
@@ -16,8 +16,7 @@ cabal-version:       >=1.10
 
 library
   hs-source-dirs:      src
-  exposed-modules:     Tonatona
-                     , Tonatona.IO
+  exposed-modules:     TonaParser
   build-depends:       base >= 4.7 && < 5
                      , envy
                      , monad-logger
@@ -59,4 +58,4 @@ test-suite tonaparser-doctest
 
 source-repository head
   type:     git
-  location: https://github.com/arow-oss/tonaparser
+  location: https://github.com/arow-oss/tonatona

--- a/tonaparser/tonaparser.cabal
+++ b/tonaparser/tonaparser.cabal
@@ -1,0 +1,62 @@
+name:                tonaparser.cabal
+version:             0.1.0.0
+synopsis:            meta web application framework
+description:
+  `Tonatona` is **meta** web application framework, which handles lots of annoying and boring tasks on real world web development such as environment variables, logging, etc...
+homepage:            http://github.com/arow-oss/tonaparser/#readme
+license:             MIT
+license-file:        LICENSE
+author:              ARoW Co., Ltd.
+maintainer:          arow.okamoto+github@gmail.com
+copyright:           2018 ARoW Co., Ltd.
+category:            Web
+build-type:          Simple
+extra-source-files:  README.md
+cabal-version:       >=1.10
+
+library
+  hs-source-dirs:      src
+  exposed-modules:     Tonatona
+                     , Tonatona.IO
+  build-depends:       base >= 4.7 && < 5
+                     , envy
+                     , monad-logger
+                     , mtl
+                     , wai
+                     , wai-extra
+                     , warp
+  default-language:    Haskell2010
+  ghc-options:         -Wall -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates -fwarn-monomorphism-restriction
+  default-extensions:  DefaultSignatures
+                     , DeriveDataTypeable
+                     , DeriveFunctor
+                     , DeriveGeneric
+                     , MultiParamTypeClasses
+                     , OverloadedStrings
+                     , RankNTypes
+                     , RecordWildCards
+                     , ScopedTypeVariables
+                     , ViewPatterns
+
+test-suite tonaparser-test
+  type:                exitcode-stdio-1.0
+  hs-source-dirs:      test
+  main-is:             Spec.hs
+  build-depends:       base
+                     , tonaparser
+  ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates -fwarn-monomorphism-restriction
+  default-language:    Haskell2010
+
+test-suite tonaparser-doctest
+  type:                exitcode-stdio-1.0
+  main-is:             DocTest.hs
+  hs-source-dirs:      test
+  build-depends:       base
+                     , doctest
+                     , Glob
+  default-language:    Haskell2010
+  ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N
+
+source-repository head
+  type:     git
+  location: https://github.com/arow-oss/tonaparser

--- a/tonaparser/tonaparser.cabal
+++ b/tonaparser/tonaparser.cabal
@@ -36,6 +36,7 @@ library
                      , DeriveDataTypeable
                      , DeriveFunctor
                      , DeriveGeneric
+                     , InstanceSigs
                      , MultiParamTypeClasses
                      , OverloadedStrings
                      , RankNTypes
@@ -54,6 +55,7 @@ executable tonaparser-example
                      , DeriveDataTypeable
                      , DeriveFunctor
                      , DeriveGeneric
+                     , InstanceSigs
                      , OverloadedStrings
                      , RankNTypes
                      , RecordWildCards


### PR DESCRIPTION
This PR only contains very beginning concept of `tonaparser`.
The `tonaparser` has ability to get environment variables and command line arguments.
It also can change key names of env vars and args, so tonatona plugins do not need to worry about key name conflictions by using simple general key names.

@cdepillabout , could you continue developing this library?

Closes #8.