### PR TITLE
Use tonaparser in the rest of tonatona

### DIFF
--- a/tonaparser/src/TonaParser.hs
+++ b/tonaparser/src/TonaParser.hs
@@ -1,6 +1,9 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
-module TonaParser where
+module TonaParser
+  ( module TonaParser
+  , module System.Envy
+  )where
 
 import Control.Monad (ap)
 import Data.Map (Map)
@@ -8,7 +11,7 @@ import qualified Data.Map as Map
 import Data.Maybe (fromMaybe, listToMaybe, mapMaybe)
 import Data.Semigroup (Semigroup, (<>))
 import System.Environment (getArgs, getEnvironment)
-import System.Envy (Var(fromVar))
+import System.Envy (Var(fromVar, toVar))
 
 {-| Example
 

--- a/tonatona-db-postgresql/src/Tonatona/Db/Postgresql.hs
+++ b/tonatona-db-postgresql/src/Tonatona/Db/Postgresql.hs
@@ -30,7 +30,6 @@ import Database.Persist.Postgresql (createPostgresqlPool)
 import Database.Persist.Sql (Migration, SqlBackend, runMigration, runSqlPool)
 import System.Envy (FromEnv(..), Var(..), (.!=), envMaybe)
 import Tonatona (TonaM, readerShared)
-import UnliftIO (MonadUnliftIO)
 
 type TonaDbM conf shared
   = ReaderT SqlBackend (TonaM conf shared)

--- a/tonatona-db-postgresql/src/Tonatona/Db/Postgresql.hs
+++ b/tonatona-db-postgresql/src/Tonatona/Db/Postgresql.hs
@@ -28,7 +28,8 @@ import Data.Pool (Pool)
 import Data.String (IsString)
 import Database.Persist.Postgresql (createPostgresqlPool)
 import Database.Persist.Sql (Migration, SqlBackend, runMigration, runSqlPool)
-import System.Envy (FromEnv(..), Var(..), (.!=), envMaybe)
+
+import TonaParser (FromEnv(..), Var(..), (.||), argLong, envDef, envVar)
 import Tonatona (TonaM, readerShared)
 
 type TonaDbM conf shared
@@ -80,9 +81,19 @@ data Config = Config
 
 instance FromEnv Config where
   fromEnv =
-    Config
-      <$> envMaybe "TONA_DB_POSTGRESQL_CONN_STRING" .!= "postgresql://myuser:mypass@localhost:5432/mydb"
-      <*> envMaybe "TONA_DB_POSTGRESQL_CONN_NUM" .!= 10
+    let connStr =
+          envDef
+            ( envVar "TONA_DB_POSTGRESQL_CONN_STRING" .||
+              argLong "postgresql-conn-string"
+            )
+            "postgresql://myuser:mypass@localhost:5432/mydb"
+        connNum =
+          envDef
+            ( envVar "TONA_DB_POSTGRESQL_CONN_NUM" .||
+              argLong "postgresql-conn-num"
+            )
+            10
+    in Config <$> connStr <*> connNum
 
 class HasConfig config where
   config :: config -> Config

--- a/tonatona-db-postgresql/tonatona-db-postgresql.cabal
+++ b/tonatona-db-postgresql/tonatona-db-postgresql.cabal
@@ -19,12 +19,12 @@ library
   exposed-modules:     Tonatona.Db.Postgresql
   build-depends:       base >= 4.7 && < 5
                      , bytestring
-                     , envy
                      , monad-logger
                      , mtl
                      , persistent
                      , persistent-postgresql
                      , resource-pool
+                     , tonaparser
                      , tonatona
                      , tonatona-environment
                      , unliftio

--- a/tonatona-db-sqlite/src/Tonatona/Db/Sqlite.hs
+++ b/tonatona-db-sqlite/src/Tonatona/Db/Sqlite.hs
@@ -30,7 +30,8 @@ import Data.Text.Encoding (decodeUtf8)
 import Database.Persist.Sqlite (createSqlitePool, wrapConnection)
 import Database.Persist.Sql (Migration, SqlBackend, runMigration, runSqlPool)
 import Database.Sqlite (open)
-import System.Envy (FromEnv(..), Var(..), (.!=), envMaybe)
+
+import TonaParser (FromEnv(..), Var(..), (.||), argLong, envDef, envVar)
 import Tonatona (TonaM, readerShared)
 
 type TonaDbM conf shared
@@ -88,9 +89,19 @@ data Config = Config
 
 instance FromEnv Config where
   fromEnv =
-    Config
-      <$> envMaybe "TONA_DB_SQLITE_CONN_STRING" .!= ":memory:"
-      <*> envMaybe "TONA_DB_SQLITE_CONN_NUM" .!= 10
+    let connStr =
+          envDef
+            ( envVar "TONA_DB_SQLITE_CONN_STRING" .||
+              argLong "sqlite-conn-string"
+            )
+            ":memory:"
+        connNum =
+          envDef
+            ( envVar "TONA_DB_SQLITE_CONN_NUM" .||
+              argLong "sqlite-conn-num"
+            )
+            10
+    in Config <$> connStr <*> connNum
 
 class HasConfig config where
   config :: config -> Config

--- a/tonatona-db-sqlite/tonatona-db-sqlite.cabal
+++ b/tonatona-db-sqlite/tonatona-db-sqlite.cabal
@@ -19,13 +19,13 @@ library
   exposed-modules:     Tonatona.Db.Sqlite
   build-depends:       base >= 4.7 && < 5
                      , bytestring
-                     , envy
                      , monad-logger
                      , mtl
                      , persistent
                      , persistent-sqlite
                      , resource-pool
                      , text
+                     , tonaparser
                      , tonatona
                      , unliftio
   default-language:    Haskell2010

--- a/tonatona-environment/src/Tonatona/Environment.hs
+++ b/tonatona-environment/src/Tonatona/Environment.hs
@@ -6,18 +6,24 @@ module Tonatona.Environment
 
 import GHC.Generics (Generic)
 import Text.Read (readMaybe)
-import System.Envy (FromEnv(..), (.!=), envMaybe)
-import qualified System.Envy as Envy
+
+import TonaParser (FromEnv(..), Var(..), (.||), argLong, argShort, envDef, envVar)
 
 data Config = Config
   { environment :: Environment
   }
   deriving (Show)
 
-
 instance FromEnv Config where
-  fromEnv = Config
-    <$> envMaybe "ENV" .!= Development
+  fromEnv =
+    let env =
+          envDef
+            ( envVar "ENV" .||
+              argLong "env" .||
+              argShort 'e'
+            )
+            Development
+    in Config <$> env
 
 class HasConfig config where
   config :: config -> Config
@@ -29,6 +35,6 @@ data Environment
   | Test
   deriving (Eq, Generic, Show, Read)
 
-instance Envy.Var Environment where
+instance Var Environment where
   toVar = show
   fromVar = readMaybe

--- a/tonatona-environment/tonatona-environment.cabal
+++ b/tonatona-environment/tonatona-environment.cabal
@@ -18,9 +18,9 @@ library
   hs-source-dirs:      src
   exposed-modules:     Tonatona.Environment
   build-depends:       base >= 4.7 && < 5
-                     , envy
                      , monad-logger
                      , mtl
+                     , tonaparser
                      , wai
                      , wai-extra
                      , warp

--- a/tonatona-logger/tonatona-logger.cabal
+++ b/tonatona-logger/tonatona-logger.cabal
@@ -19,7 +19,6 @@ library
   exposed-modules:     Tonatona.Logger
   build-depends:       base >= 4.7 && < 5
                      , bytestring
-                     , envy
                      , monad-logger
                      , mtl
                      , tonatona

--- a/tonatona-sample/src/Tonatona/Sample.hs
+++ b/tonatona-sample/src/Tonatona/Sample.hs
@@ -16,8 +16,8 @@ import Data.Text (Text)
 import Data.Void (Void, absurd)
 import Database.Persist.Sql (Migration, SqlBackend, (==.), entityVal, insert_, selectList)
 import Database.Persist.TH (mkMigrate, mkPersist, mpsGenerateLenses, persistLowerCase, share, sqlSettings)
-import System.Envy (FromEnv(..), Var(..), (.!=), envMaybe)
 import Servant
+import TonaParser (FromEnv(..), Var(..), (.||), argLong, envDef, envVar)
 import Tonatona (Plug(..), TonaM, askConf)
 import qualified Tonatona as Tona
 import qualified Tonatona.Db.Postgresql as TonaDbPostgres
@@ -109,7 +109,7 @@ app =
 data DbToUse = PostgreSQL | Sqlite deriving Show
 
 instance FromEnv DbToUse where
-  fromEnv = envMaybe "DB_TO_USE" .!= PostgreSQL
+  fromEnv = envDef (envVar "DB_TO_USE" .|| argLong "db-to-use") PostgreSQL
 
 instance Var DbToUse where
   toVar PostgreSQL = "postgresql"

--- a/tonatona-sample/tonatona-sample.cabal
+++ b/tonatona-sample/tonatona-sample.cabal
@@ -19,7 +19,6 @@ library
   exposed-modules:     Tonatona.Sample
   build-depends:       base >= 4.7 && < 5
                      , aeson
-                     , envy
                      , mtl
                      , persistent
                      , persistent-postgresql
@@ -27,6 +26,7 @@ library
                      , servant
                      , servant-server
                      , text
+                     , tonaparser
                      , tonatona
                      , tonatona-db-postgresql
                      , tonatona-db-sqlite

--- a/tonatona-servant/tonatona-servant.cabal
+++ b/tonatona-servant/tonatona-servant.cabal
@@ -19,7 +19,6 @@ library
   exposed-modules:     Tonatona.Servant
   build-depends:       base >= 4.7 && < 5
                      , bytestring
-                     , envy
                      , exceptions
                      , http-types
                      , monad-logger
@@ -27,6 +26,7 @@ library
                      , servant
                      , servant-server
                      , text
+                     , tonaparser
                      , tonatona
                      , tonatona-environment
                      , wai

--- a/tonatona/src/Tonatona.hs
+++ b/tonatona/src/Tonatona.hs
@@ -15,8 +15,8 @@ module Tonatona
 
 import Control.Monad.Reader (ReaderT, runReaderT, reader)
 import Control.Monad.Trans (lift)
-import Data.Semigroup ((<>))
-import System.Envy (FromEnv, decodeEnv)
+
+import TonaParser (FromEnv, decodeEnv)
 
 {-| Main type
  - TODO make this an opaque type, and appropreate Monad instead of `IO`
@@ -30,8 +30,8 @@ run :: Plug conf shared => TonaM conf shared a -> IO a
 run action = do
   mconf <- decodeEnv
   case mconf of
-    Left err -> error $ "Fail to decode env: " <> err
-    Right conf -> runWithConf conf action
+    Nothing -> error "Fail to decode env"
+    Just conf -> runWithConf conf action
 
 runWithConf :: Plug conf shared => conf -> TonaM conf shared a -> IO a
 runWithConf conf action = do

--- a/tonatona/tonatona.cabal
+++ b/tonatona/tonatona.cabal
@@ -19,9 +19,9 @@ library
   exposed-modules:     Tonatona
                      , Tonatona.IO
   build-depends:       base >= 4.7 && < 5
-                     , envy
                      , monad-logger
                      , mtl
+                     , tonaparser
                      , wai
                      , wai-extra
                      , warp


### PR DESCRIPTION
This PR makes use of tonaparser (instead of envy) in the rest of tonatona.

@arowM I'm going to go ahead and merge this in so that I can start using it in goat guardian, but please feel free to leave a comment if you think anything should be changed!  We can fix it before actually doing a release.