### PR TITLE
Change environment variables to be shorter.

### DIFF
--- a/tonatona-db-postgresql/src/Tonatona/Db/Postgresql.hs
+++ b/tonatona-db-postgresql/src/Tonatona/Db/Postgresql.hs
@@ -84,13 +84,13 @@ instance FromEnv Config where
     let connStr =
           envDef
             ( argLong "postgresql-conn-string" .||
-              envVar "TONA_DB_POSTGRESQL_CONN_STRING"
+              envVar "DB_CONN_STRING"
             )
             "postgresql://myuser:mypass@localhost:5432/mydb"
         connNum =
           envDef
             ( argLong "postgresql-conn-num" .||
-              envVar "TONA_DB_POSTGRESQL_CONN_NUM"
+              envVar "DB_CONN_NUM"
             )
             10
     in Config <$> connStr <*> connNum

--- a/tonatona-db-postgresql/src/Tonatona/Db/Postgresql.hs
+++ b/tonatona-db-postgresql/src/Tonatona/Db/Postgresql.hs
@@ -83,13 +83,13 @@ instance FromEnv Config where
   fromEnv =
     let connStr =
           envDef
-            ( argLong "postgresql-conn-string" .||
+            ( argLong "db-conn-string" .||
               envVar "DB_CONN_STRING"
             )
             "postgresql://myuser:mypass@localhost:5432/mydb"
         connNum =
           envDef
-            ( argLong "postgresql-conn-num" .||
+            ( argLong "db-conn-num" .||
               envVar "DB_CONN_NUM"
             )
             10

--- a/tonatona-db-sqlite/src/Tonatona/Db/Sqlite.hs
+++ b/tonatona-db-sqlite/src/Tonatona/Db/Sqlite.hs
@@ -91,13 +91,13 @@ instance FromEnv Config where
   fromEnv =
     let connStr =
           envDef
-            ( argLong "sqlite-conn-string" .||
+            ( argLong "db-conn-string" .||
               envVar "DB_CONN_STRING"
             )
             ":memory:"
         connNum =
           envDef
-            ( argLong "sqlite-conn-num" .||
+            ( argLong "db-conn-num" .||
               envVar "DB_CONN_NUM"
             )
             10

--- a/tonatona-db-sqlite/src/Tonatona/Db/Sqlite.hs
+++ b/tonatona-db-sqlite/src/Tonatona/Db/Sqlite.hs
@@ -92,13 +92,13 @@ instance FromEnv Config where
     let connStr =
           envDef
             ( argLong "sqlite-conn-string" .||
-              envVar "TONA_DB_SQLITE_CONN_STRING"
+              envVar "DB_CONN_STRING"
             )
             ":memory:"
         connNum =
           envDef
             ( argLong "sqlite-conn-num" .||
-              envVar "TONA_DB_SQLITE_CONN_NUM"
+              envVar "DB_CONN_NUM"
             )
             10
     in Config <$> connStr <*> connNum

--- a/tonatona-sample/src/Tonatona/Sample.hs
+++ b/tonatona-sample/src/Tonatona/Sample.hs
@@ -17,7 +17,7 @@ import Data.Void (Void, absurd)
 import Database.Persist.Sql (Migration, SqlBackend, (==.), entityVal, insert_, selectList)
 import Database.Persist.TH (mkMigrate, mkPersist, mpsGenerateLenses, persistLowerCase, share, sqlSettings)
 import Servant
-import TonaParser (FromEnv(..), Var(..), (.||), argLong, envDef, envVar)
+import TonaParser (FromEnv(..), ParserMods(..), Var(..), (.||), argLong, defParserMods, envDef, envVar, fromEnvWithMods)
 import Tonatona (Plug(..), TonaM, askConf)
 import qualified Tonatona as Tona
 import qualified Tonatona.Db.Postgresql as TonaDbPostgres
@@ -130,12 +130,19 @@ data Config = Config
 
 instance FromEnv Config where
   fromEnv =
-    Config
-      <$> fromEnv
-      <*> fromEnv
-      <*> fromEnv
-      <*> fromEnv
-      <*> fromEnv
+    let postgres =
+          fromEnvWithMods
+            defParserMods
+              { envVarMods = ("POSTGRESQL_" <>)
+              , cmdLineLongMods = ("postgresql-" <>)
+              }
+        sqlite =
+          fromEnvWithMods
+            defParserMods
+              { envVarMods = ("SQLITE_" <>)
+              , cmdLineLongMods = ("sqlite-" <>)
+              }
+    in Config <$> postgres <*> sqlite <*> fromEnv <*> fromEnv <*> fromEnv
 
 instance TonaDbPostgres.HasConfig Config where
   config = tonaDbPostgres

--- a/tonatona-servant/src/Tonatona/Servant.hs
+++ b/tonatona-servant/src/Tonatona/Servant.hs
@@ -128,26 +128,26 @@ instance FromEnv Config where
           envDef
             ( argLong "host" .||
               argShort 'h' .||
-              envVar "TONA_SERVANT_HOST"
+              envVar "HOST"
             )
             ("localhost" :: Host)
         protocol =
           envDef
             ( argLong "protocol" .||
-              envVar "TONA_SERVANT_PROTOCOL"
+              envVar "PROTOCOL"
             )
             ("http" :: Protocol)
         port =
           envDef
             ( argLong "port" .||
               argShort 'p' .||
-              envVar "TONA_SERVANT_PORT"
+              envVar "PORT"
             )
             (8000 :: Port)
         reqlog =
           envDef
             ( argLong "reqlog" .||
-              envVar "TONA_SERVANT_REQLOG"
+              envVar "REQLOG"
             )
             ReqLogVerbose
     in Config <$> host <*> protocol <*> port <*> reqlog


### PR DESCRIPTION
This PR makes the following changes:

- TONA_DB_POSTGRESQL_CONN_STRING -> DB_CONN_STRING
- TONA_DB_POSTGRESQL_CONN_NUM -> DB_CONN_NUM
- TONA_DB_SQLITE_CONN_STRING -> DB_CONN_STRING
- TONA_DB_SQLITE_CONN_NUM -> DB_CONN_NUM
- TONA_SERVANT_HOST -> HOST
- TONA_SERVANT_PROTOCOL -> PROTOCOL
- TONA_SERVANT_PORT -> PORT
- TONA_SERVANT_REQLOG -> REQLOG

If you want to use the postgresql and sqlite plugins in the same
application, you'll need to change at least one of these, since now they
are the same value.

This fixes #26.