### PR TITLE
Hide everything to do with the short-hand arguments so the user can't use them yet.

### DIFF
--- a/tonaparser/example/Main.hs
+++ b/tonaparser/example/Main.hs
@@ -9,7 +9,6 @@ import TonaParser
   , ParserMods(..)
   , (.||)
   , argLong
-  , argShort
   , decodeEnvWith
   , defParserRenames
   , defParserMods
@@ -34,7 +33,7 @@ data Foo = Foo
 -- else use default value "baz"
 instance FromEnv Bar where
   fromEnv = Bar
-    <$> envDef (argLong "baz" .|| argShort 'b' .|| envVar "BAZ") "baz"
+    <$> envDef (argLong "baz" .|| envVar "BAZ") "baz"
 
 barWithPrefix :: Parser Bar
 barWithPrefix =
@@ -55,7 +54,6 @@ main = do
   let renames =
         defParserRenames
           { cmdLineLongRenames = [("foo", "new-foo")]
-          , cmdLineShortRenames = [('b', 'c')]
           , envVarRenames = [("BAR_BAZ", "NEW_BAR_BAZ")]
           }
   (foo :: Maybe Foo) <- decodeEnvWith renames defParserMods

--- a/tonaparser/src/TonaParser.hs
+++ b/tonaparser/src/TonaParser.hs
@@ -1,8 +1,31 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 module TonaParser
-  ( module TonaParser
-  , module System.Envy
+  ( module System.Envy
+  , decodeEnv
+  , decodeEnvWith
+  , FromEnv(..)
+  , fromEnvWith
+  , fromEnvWithRenames
+  , fromEnvWithMods
+  , modifyParserWith
+  , modifyParserWithRenames
+  , modifyParserWithMods
+  , env
+  , envDef
+  , Parser
+  , defParserRenames
+  , ParserRenames
+  , cmdLineLongRenames
+  , envVarRenames
+  , defParserMods
+  , ParserMods
+  , cmdLineLongMods
+  , envVarMods
+  , Source
+  , (.||)
+  , envVar
+  , argLong
   )where
 
 import Control.Monad (ap)

--- a/tonatona-environment/src/Tonatona/Environment.hs
+++ b/tonatona-environment/src/Tonatona/Environment.hs
@@ -7,7 +7,7 @@ module Tonatona.Environment
 import GHC.Generics (Generic)
 import Text.Read (readMaybe)
 
-import TonaParser (FromEnv(..), Var(..), (.||), argLong, argShort, envDef, envVar)
+import TonaParser (FromEnv(..), Var(..), (.||), argLong, envDef, envVar)
 
 data Config = Config
   { environment :: Environment
@@ -19,7 +19,6 @@ instance FromEnv Config where
     let env =
           envDef
             ( argLong "env" .||
-              argShort 'e' .||
               envVar "ENV"
             )
             Development

--- a/tonatona-servant/src/Tonatona/Servant.hs
+++ b/tonatona-servant/src/Tonatona/Servant.hs
@@ -29,7 +29,7 @@ import qualified Network.Wai.Handler.Warp as Warp
 import Network.Wai.Middleware.RequestLogger (logStdout, logStdoutDev)
 import Servant
 
-import TonaParser (FromEnv(..), Var(..), (.||), argLong, argShort, envDef, envVar)
+import TonaParser (FromEnv(..), Var(..), (.||), argLong, envDef, envVar)
 import Tonatona (Plug, TonaM)
 
 reqLogMiddleware :: HasConfig conf => TonaM conf shared Middleware
@@ -127,7 +127,6 @@ instance FromEnv Config where
     let host =
           envDef
             ( argLong "host" .||
-              argShort 'h' .||
               envVar "HOST"
             )
             ("localhost" :: Host)
@@ -140,7 +139,6 @@ instance FromEnv Config where
         port =
           envDef
             ( argLong "port" .||
-              argShort 'p' .||
               envVar "PORT"
             )
             (8000 :: Port)


### PR DESCRIPTION
This PR hides everything about short hand arguments so the end user can't use them yet.

At some point when we move to an API more similar to optparse-applicative, we may enable them again.  See the discussion at https://github.com/arow-oss/tonatona/issues/27#issuecomment-414957917 and https://github.com/arow-oss/tonatona/issues/27#issuecomment-415113405.

This PR fixes #27.